### PR TITLE
Drain example bounded

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -249,7 +249,7 @@ impl<T> Bounded<T> {
                     if tail & self.mark_bit != 0 {
                         return Err(PopError::Closed);
                     } else {
-                        return Ok(Vec::new());
+                        return Err(PopError::Empty);
                     }
                 } else {
                     self.cap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,50 @@ impl<T> ConcurrentQueue<T> {
         }
     }
 
+    /// Drains the queue returning all availalbe items in a vector.
+    ///
+    /// If the queue is closed, an error is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use concurrent_queue::{ConcurrentQueue, PopError};
+    ///
+    /// let q = ConcurrentQueue::bounded(3);
+    ///
+    /// // Drain an empty vector when the queue is empty.
+    /// assert_eq!(dbg!(q.drain()), Ok(vec![]));
+    ///
+    /// // Push one item and close the queue.
+    /// assert_eq!(q.push(10), Ok(()));
+    ///
+    /// // Drain returns one element.
+    /// assert_eq!(dbg!(q.drain()), Ok(vec![10]));
+    ///
+    /// // Push one item and close the queue.
+    /// assert_eq!(q.push(11), Ok(()));
+    ///
+    /// // Push one item and close the queue.
+    /// assert_eq!(q.push(12), Ok(()));
+    ///
+    /// // Push one item and close the queue.
+    /// assert_eq!(q.push(13), Ok(()));
+    /// q.close();
+    ///
+    /// // Remaining items can be popped.
+    /// assert_eq!(dbg!(q.drain()), Ok(vec![11, 12, 13]));
+    ///
+    /// // Again, pop errors when the queue is empty,
+    /// // but now also indicates that the queue is closed.
+    /// assert_eq!(dbg!(q.drain()), Err(PopError::Closed));
+    /// ```
+    pub fn drain(&self) -> Result<Vec<T>, PopError> {
+        match &self.0 {
+            Inner::Bounded(q) => q.drain(),
+            Inner::Unbounded(_q) => unimplemented!(),
+        }
+    }
+
     /// Returns `true` if the queue is empty.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ impl<T> ConcurrentQueue<T> {
     /// Drains the queue returning all availalbe items in a vector.
     ///
     /// If the queue is closed, an error is returned.
+    /// If the queue is empty, an error is returned.
     ///
     /// # Examples
     ///
@@ -179,7 +180,7 @@ impl<T> ConcurrentQueue<T> {
     /// let q = ConcurrentQueue::bounded(3);
     ///
     /// // Drain an empty vector when the queue is empty.
-    /// assert_eq!(dbg!(q.drain()), Ok(vec![]));
+    /// assert_eq!(dbg!(q.drain()), Err(PopError::Empty));
     ///
     /// // Push one item and close the queue.
     /// assert_eq!(q.push(10), Ok(()));


### PR DESCRIPTION
This adds a `drain` function that will return all elements that can be read at the time of the call if a queue has more then one element this can reduce the number of load/compare_exchange operations at the cost of being more expensive at a queue with a single element.

the unbounded queue is so far unimplemented as I wanted to get some feedback first I'll add it before moving out of Draft.